### PR TITLE
Add support for anonymous and derived types.

### DIFF
--- a/StencilBox.Tests/ProcessTests.cs
+++ b/StencilBox.Tests/ProcessTests.cs
@@ -80,7 +80,7 @@ namespace StencilBox.Tests
         }
 
         [TestMethod]
-        public void Stencil_handles_anonymouse_types_passed_as_object()
+        public void Stencil_handles_anonymous_types_passed_as_object()
         {
             const string template = "[~Id]: [~Name]";
             const string expectedOutput = "123: Item Name";

--- a/StencilBox.Tests/ProcessTests.cs
+++ b/StencilBox.Tests/ProcessTests.cs
@@ -14,6 +14,11 @@ namespace StencilBox.Tests
             public DateTime TestDate { get; set; }
         }
 
+        public class DerivedModel : TestModel
+        {
+            public string Name { get; set; }
+        }
+
         [TestMethod]
         public void Stencil_handles_normal_brackets_correctly()
         {
@@ -72,6 +77,40 @@ namespace StencilBox.Tests
             var output = Stencil.Apply(template, model);
 
             Assert.AreEqual(expectedOutput, output);
+        }
+
+        [TestMethod]
+        public void Stencil_handles_anonymouse_types_passed_as_object()
+        {
+            const string template = "[~Id]: [~Name]";
+            const string expectedOutput = "123: Item Name";
+            var model = new { Id = 123, Name = "Item Name" };
+
+            var output = ApplyStencilToAnonymousType(template, model);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        private string ApplyStencilToAnonymousType(string template, object model)
+        {
+            return Stencil.Apply(template, model);
+        }
+
+        [TestMethod]
+        public void Stencil_handles_sub_types_passed_as_super_type()
+        {
+            const string template = "[~Name]: [~Description]";
+            const string expectedOutput = "Child Name: Parent Description";
+            var model = new DerivedModel { Name = "Child Name", Description = "Parent Description" };
+
+            var output = ApplyStencilToSubType(template, model);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        private string ApplyStencilToSubType(string template, TestModel model)
+        {
+            return Stencil.Apply(template, model);
         }
     }
 }

--- a/StencilBox/StencilBox.cs
+++ b/StencilBox/StencilBox.cs
@@ -34,14 +34,14 @@
 	public static class Stencil
 	{
 		// TODO: document this thing
-        public static string Apply<T>(string template, T source, Dictionary<string, string> manualReplacements = null, ProcessFlags flags = ProcessFlags.None) where T : class
+        public static string Apply(string template, object source, Dictionary<string, string> manualReplacements = null, ProcessFlags flags = ProcessFlags.None)
 		{
 			var output = template;
 
 			if (source != null)
 			{
-				IEnumerable<PropertyInfo> properties =
-					typeof(T).GetProperties(BindingFlags.SetProperty | BindingFlags.Public | BindingFlags.Instance);
+                IEnumerable<PropertyInfo> properties =
+                    source.GetType().GetProperties(BindingFlags.SetProperty | BindingFlags.Public | BindingFlags.Instance);
 
 				foreach (var info in properties)
 				{


### PR DESCRIPTION
With the current implementation, if I have a child type that I pass to a function that takes it's parent type as a parameter, none of the child properties can be used in the stencil.

With this modification, any object can be passed (including derived or anonymous types) and any property that is on the type will be available to the stencil.
